### PR TITLE
Return 'value' instead of 'targets'.

### DIFF
--- a/tasks/targets.rb
+++ b/tasks/targets.rb
@@ -182,7 +182,7 @@ vagrant = Bolt::Vagrant.new(params)
 targets = vagrant.inventory_targets
 
 result = {
-  'targets' => targets,
+  'value' => targets,
 }
 
 puts(result.to_json)


### PR DESCRIPTION
A recent bolt update (specifically c4891ad27) changed the key it looks
for in the task output from 'targets' to 'value'.  This changes the
output to match the expected result.