### PR TITLE
Add a "match" parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ targets:
 **`vagrant_dir`:** The location of the Vagrant directory, defaults to `cwd`
 
 **`winrm_regex`:** A regular expression used to determine which machines should be connected to using winrm. Unfortunately Vagrant doesn't give that information out at the command line and there is no way of working it out. This regex is passed to `Regexp.new()` as a string. Running the `targets.rb` file manually will provide debugging info.
+
+**`match`:** A regular expression used to determine which machines should be returned in the inventory. This regex is passed to `Regexp.new()` as a string.

--- a/tasks/targets.json
+++ b/tasks/targets.json
@@ -8,8 +8,12 @@
       "type": "Optional[String]"
     },
     "winrm_regex": {
-      "description": "Machines that match this will be connected to using winrm. Otherwise SSH will be used/",
-      "type": "Optional[String]"
+      "description": "Machines that match this will be connected to using winrm. Otherwise SSH will be used.",
+      "type": "Optional[Pattern]"
+    },
+    "match": {
+      "description": "Machines that match this will be included in the inventory.",
+      "type": "Optional[Pattern]"
     }
   }
 }

--- a/tasks/targets.rb
+++ b/tasks/targets.rb
@@ -14,6 +14,7 @@ module Bolt # rubocop:disable Style/ClassAndModuleChildren
       @vagrant_dir    = opts['vagrant_dir'] || Dir.pwd
       @vagrant_binary = which('vagrant')
       @winrm_regex    = Regexp.new(opts['winrm_regex'] || 'windows')
+      @node_match     = opts['match'].nil? ? nil : Regexp.new(opts['match'])
     end
 
     def inventory_targets
@@ -21,6 +22,10 @@ module Bolt # rubocop:disable Style/ClassAndModuleChildren
 
       # Get the running nodes using vagrant status
       running_nodes = status.keep_if { |_name, details| details['state'] == 'running' }
+
+      unless @node_match.nil?
+        running_nodes = running_nodes.select { |n, _d| @node_match.match?(n) }
+      end
 
       # Split into winrm and ssh transports
       winrm_nodes = running_nodes.select { |n, _d| @winrm_regex.match?(n) }


### PR DESCRIPTION
This adds a parameter "match" which can be used to limit the inventory
returned based on a regex.

This idea was inspired by @branan's vagrant::inventory task from his
Puppetize PDX 2019 demo.

In addition, this includes minor fixes for the "winrm_regex" parameter
metadata.