### PR TITLE
Pass hosts to vagrant ssh-config/winrm-config as a list instead of regex

### DIFF
--- a/tasks/targets.rb
+++ b/tasks/targets.rb
@@ -73,10 +73,10 @@ module Bolt # rubocop:disable Style/ClassAndModuleChildren
     end
 
     def ssh_config(hosts)
-      hosts_regex = "/#{hosts.join('|')}/"
+      hosts_list = "#{hosts.join(' ')}"
 
-      debug("Running 'vagrant ssh-config '#{hosts_regex}'' to get the ssh details")
-      hosts = parse_machine_readable(exec("#{@vagrant_binary} ssh-config '#{hosts_regex}' --machine-readable"))
+      debug("Running 'vagrant ssh-config #{hosts_list}' to get the ssh details")
+      hosts = parse_machine_readable(exec("#{@vagrant_binary} ssh-config #{hosts_list} --machine-readable"))
 
       # Delete all non-winrm hosts
       hosts.keep_if { |_n, d| d.key? 'ssh-config' }
@@ -90,10 +90,10 @@ module Bolt # rubocop:disable Style/ClassAndModuleChildren
     end
 
     def winrm_config(hosts)
-      hosts_regex = "/#{hosts.join('|')}/"
+      hosts_list = "#{hosts.join(' ')}"
 
-      debug("Running 'vagrant winrm-config '#{hosts_regex}'' to get the ssh details")
-      hosts = parse_machine_readable(exec("#{@vagrant_binary} winrm-config '#{hosts_regex}' --machine-readable"))
+      debug("Running 'vagrant winrm-config #{hosts_list}' to get the ssh details")
+      hosts = parse_machine_readable(exec("#{@vagrant_binary} winrm-config #{hosts_list} --machine-readable"))
 
       # Delete all non-winrm hosts
       hosts.keep_if { |_n, d| d.key? 'winrm-config' }


### PR DESCRIPTION
Narrow 'vagrant ssh-config' and 'vagrant winrm-config' output to only
specific hosts to avoid host names being used as regexes.