### PR TITLE
Fix SSH connectivity issues

### DIFF
--- a/tasks/targets.rb
+++ b/tasks/targets.rb
@@ -46,6 +46,7 @@ module Bolt # rubocop:disable Style/ClassAndModuleChildren
               'run-as'         => 'root',
               'private-key'    => config['IdentityFile'],
               'host-key-check' => false,
+              'load-config'    => false,
             },
           },
         }


### PR DESCRIPTION
If load-config is enabled then connectivity to Vagrant VMs fails with very
little hint as to why. This behavior can be reproduced even if ~/.ssh/config
is not present.

Signed-off-by: Samuli Seppänen <samuli.seppanen@puppeteers.net>